### PR TITLE
Add support for level v8 databases

### DIFF
--- a/lib/register-db.js
+++ b/lib/register-db.js
@@ -40,10 +40,24 @@ function createDbRegister (pwd, _path, _require = require) {
       return dbs.get(name)
     }
 
-    const db = level(
-      path.resolve(dbPath, name),
-      {valueEncoding: 'json'}
-    )
+    let db
+    try {
+      // Level pre-v8
+      db = level(
+        path.resolve(dbPath, name),
+        {valueEncoding: 'json'}
+      )
+    } catch (err) {
+      if (err instanceof TypeError && level.Level) {
+        // Level v8
+        db = new level.Level(
+          path.resolve(dbPath, name),
+          {valueEncoding: 'json'}
+        )
+      } else {
+        throw err
+      }
+    }
 
     dbs.set(name, db)
 


### PR DESCRIPTION
In 8.0.0, Level changed database initialization to use a constructor instead of a function call. For backwards compatibility, this attempts to initialize a pre-v8 database, and if that fails it will initialize a v8 database.